### PR TITLE
Fix PHP 7.4 deprecation: array/string curly braces access

### DIFF
--- a/Console/Getopt.php
+++ b/Console/Getopt.php
@@ -138,10 +138,10 @@ class Console_Getopt
                 break;
             }
 
-            if ($arg{0} != '-' || (strlen($arg) > 1 && $arg{1} == '-' && !$long_options)) {
+            if ($arg[0] != '-' || (strlen($arg) > 1 && $arg[1] == '-' && !$long_options)) {
                 $non_opts = array_merge($non_opts, array_slice($args, $i));
                 break;
-            } elseif (strlen($arg) > 1 && $arg{1} == '-') {
+            } elseif (strlen($arg) > 1 && $arg[1] == '-') {
                 $error = Console_Getopt::_parseLongOption(substr($arg, 2),
                                                           $long_options,
                                                           $opts,
@@ -186,11 +186,11 @@ class Console_Getopt
     protected static function _parseShortOption($arg, $short_options, &$opts, &$argIdx, $args, $skip_unknown)
     {
         for ($i = 0; $i < strlen($arg); $i++) {
-            $opt     = $arg{$i};
+            $opt     = $arg[$i];
             $opt_arg = null;
 
             /* Try to find the short option in the specifier string. */
-            if (($spec = strstr($short_options, $opt)) === false || $arg{$i} == ':') {
+            if (($spec = strstr($short_options, $opt)) === false || $arg[$i] == ':') {
                 if ($skip_unknown === true) {
                     break;
                 }
@@ -199,8 +199,8 @@ class Console_Getopt
                 return PEAR::raiseError($msg);
             }
 
-            if (strlen($spec) > 1 && $spec{1} == ':') {
-                if (strlen($spec) > 2 && $spec{2} == ':') {
+            if (strlen($spec) > 1 && $spec[1] == ':') {
+                if (strlen($spec) > 2 && $spec[2] == ':') {
                     if ($i + 1 < strlen($arg)) {
                         /* Option takes an optional argument. Use the remainder of
                            the arg string if there is anything left. */
@@ -296,11 +296,11 @@ class Console_Getopt
                 $next_option_rest = '';
             }
 
-            if ($opt_rest != '' && $opt{0} != '=' &&
+            if ($opt_rest != '' && $opt[0] != '=' &&
                 $i + 1 < count($long_options) &&
                 $opt == substr($long_options[$i+1], 0, $opt_len) &&
                 $next_option_rest != '' &&
-                $next_option_rest{0} != '=') {
+                $next_option_rest[0] != '=') {
 
                 $msg = "Console_Getopt: option --$opt is ambiguous";
                 return PEAR::raiseError($msg);


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated

Hopefully these are all (or most) of them:
```
[Clover@Clover-NB rc]$ rg -tphp "(\\$|->|::)[A-Za-z0-9_]+\{"
vendor\pear\console_getopt\Console\Getopt.php:141:            if ($arg{0} != '-' || (strlen($arg) > 1 && $arg{1} == '-' && !$long_options)) {
vendor\pear\console_getopt\Console\Getopt.php:144:            } elseif (strlen($arg) > 1 && $arg{1} == '-') {
vendor\pear\console_getopt\Console\Getopt.php:189:            $opt     = $arg{$i};
vendor\pear\console_getopt\Console\Getopt.php:193:            if (($spec = strstr($short_options, $opt)) === false || $arg{$i} == ':') {
vendor\pear\console_getopt\Console\Getopt.php:202:            if (strlen($spec) > 1 && $spec{1} == ':') {
vendor\pear\console_getopt\Console\Getopt.php:203:                if (strlen($spec) > 2 && $spec{2} == ':') {
vendor\pear\console_getopt\Console\Getopt.php:299:            if ($opt_rest != '' && $opt{0} != '=' &&
vendor\pear\console_getopt\Console\Getopt.php:303:                $next_option_rest{0} != '=') {
```

https://github.com/php/php-src/blob/0e6e2297fcb27103cc5d550ee8434680ff1e879e/UPGRADING#L356-L357
