### PR TITLE
fix phplint warnings

### DIFF
--- a/Console/Getopt.php
+++ b/Console/Getopt.php
@@ -123,7 +123,7 @@ class Console_Getopt
          * erroneous POSIX fix.
          */
         if ($version < 2) {
-            if (isset($args[0]{0}) && $args[0]{0} != '-') {
+            if (isset($args[0][0]) && $args[0][0] != '-') {
                 array_shift($args);
             }
         }


### PR DESCRIPTION
Missing in PR #4 
```
$ find . -name \*.php -exec php74 -l {} \;
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in ./Console/Getopt.php on line 126
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in ./Console/Getopt.php on line 126
No syntax errors detected in ./Console/Getopt.php

```