### PR TITLE
No hard dependency on phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "source": "https://github.com/pear/Console_Getopt"
     },
     "type": "library",
-    "require": {
+    "require-dev": {
         "phpunit/phpunit": "<=8"
     }
 }


### PR DESCRIPTION
There should not be any hard dependency on phpunit for runtime. The require should either be require-dev (only install if console_getopt is the root package) or suggest (don't auto-install, only show a suggestion on installing.